### PR TITLE
[고도화] MySQL -> PostgreSQL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'
+	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,13 +9,9 @@ logging:
 
 spring:
   datasource:
-#    url: jdbc:mysql://localhost:3306/board #${LOCAL_DB_URL}
-#    username: uno #${LOCAL_DB_USERNAME}
-#    password: thisisTESTpw!#%& #${LOCAL_DB_PASSWORD}
-#    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:h2:mem:testdb #${LOCAL_DB_URL}
-    username: sa #${LOCAL_DB_USERNAME}
-    driver-class-name: org.h2.Driver
+    url: jdbc:postgresql://localhost:5432/board #${LOCAL_DB_URL}
+    username: chris #${LOCAL_DB_USERNAME}
+    password: 1234 #${LOCAL_DB_PASSWORD}
   jpa:
     open-in-view: false
     defer-datasource-initialization: true


### PR DESCRIPTION
JPA의 이점을 활용하여, 간단하게 프로젝트 DB를 MySQL -> PostgreSQL로 전환 성공.

This closes #62 